### PR TITLE
LPS-83386 Prevent table cell to split if tilde and named link are present in it

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -227,10 +227,10 @@ Parse.Simple.Creole = function(options) {
         tr: { tag: 'tr', capture: 2, regex: /(^|\n)(\|.*?)\|?[ \t]*(\n|$)/ },
         th: { tag: 'th', regex: /\|+=([^|]*)/, capture: 1 },
         td: { tag: 'td', capture: 1,
-            regex: '\\|([^|~\\[{]*((~(.|(?=\\n)|$)|' +
-                   '(?:\\[\\[' + rx.link + '(\\|' + rx.linkText + ')?\\]\\][^|~\\[{]*)*' +
+            regex: '\\|(([^|~\\[{]*(~(.|(?=\\n)|$))*' +
+                   '(?:\\[\\[' + rx.link + '(\\|' + rx.linkText + ')?\\]\\]' +
                    (options && options.strict ? '' : '|' + rx.img) +
-                   '|[\\[{])[^|~]*)*)' },
+                   '|[\\[{])*)*)' },
 
         singleLine: { regex: /.+/, capture: 0 },
         paragraph: { tag: 'p', capture: 0,


### PR DESCRIPTION
Hi @jbalsas ,
Can you please have a look at this fix?

Thanks,
Balazs