### PR TITLE
LPS-87549 Handle onBlur for categories: create if the typed category exists or show an error if not

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelector.soy
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelector.soy
@@ -12,7 +12,7 @@
 	{@param vocabularies: list<?>}
 	{@param? _handleInputFocus: any}
 
-	<div>
+	<div id="{$id}">
 		{foreach $vocabulary in $vocabularies}
 			<div class="field-content">
 				<label id="namespace_assetCategoriesLabel_{$vocabulary.id}">

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -119,6 +119,27 @@ class AssetVocabularyCategoriesSelector extends Component {
 	 */
 	_handleInputOnBlur(event) {
 		event.preventDefault();
+
+		const filteredItems = event.target.filteredItems;
+		const inputValue = event.target.inputValue;
+
+		if (filteredItems && filteredItems.length > 0 && filteredItems[0].data.label === inputValue) {
+			const existingCategory = this.selectedItems.find(category => category.label === inputValue);
+
+			if (!existingCategory) {
+				const item = {
+					label: filteredItems[0].data.label,
+					value: filteredItems[0].data.value
+				};
+
+				this.selectedItems = this.selectedItems.concat(item);
+				event.target.inputValue = '';
+			}
+		}
+		else if (inputValue) {
+			this._typedCategory = inputValue;
+			this._unexistingCategoryError = true;
+		}
 	}
 
 	/**

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -109,13 +109,13 @@ class AssetVocabularyCategoriesSelector extends Component {
 	}
 
 	/**
-	 * Hides the category error
+	 * Prevent auto clean
 	 *
 	 * @private
 	 * @review
 	 */
-	_handleInputOnBlur() {
-		this._unexistingCategoryError = false;
+	_handleInputOnBlur(event) {
+		event.preventDefault();
 	}
 
 	/**

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -104,8 +104,11 @@ class AssetVocabularyCategoriesSelector extends Component {
 	 * @private
 	 * @review
 	 */
-	_handleErrorAddinglabelItem() {
-		this._unexistingCategoryError = true;
+	_handleErrorAddinglabelItem(event) {
+		if (event.data.itemDoesNotExists) {
+			this._typedCategory = event.target.inputValue;
+			this._unexistingCategoryError = true;
+		}
 	}
 
 	/**

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -99,6 +99,16 @@ class AssetVocabularyCategoriesSelector extends Component {
 	}
 
 	/**
+	 * Show the category error
+	 *
+	 * @private
+	 * @review
+	 */
+	_handleErrorAddinglabelItem() {
+		this._unexistingCategoryError = true;
+	}
+
+	/**
 	 * Hides the category error
 	 *
 	 * @private
@@ -130,8 +140,15 @@ class AssetVocabularyCategoriesSelector extends Component {
 		this.selectedItems = event.data.selectedItems;
 	}
 
+	/**
+	 * Sync the _intpuvalue and hide the category error
+	 *
+	 * @private
+	 * @review
+	 */
 	_handleSyncInputValue(val) {
 		this._inputValue = val.newVal;
+		this._unexistingCategoryError = false;
 	}
 
 	syncSelectedItems() {

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
@@ -28,6 +28,7 @@
 
 		{call ClayMultiSelect.render}
 			{param autocompleteFilterCondition: 'label' /}
+			{param creatable: false /}
 			{param dataSource: $_dataSource ?: [] /}
 			{param events: [
 				'inputBlur': $_handleInputOnBlur,

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.soy
@@ -9,6 +9,7 @@
 	{@param spritemap: string}
 	{@param? _dataSource: ?}
 	{@param? _handleButtonClicked: any}
+	{@param? _handleErrorAddinglabelItem: any}
 	{@param? _handleInputFocus: any}
 	{@param? _handleInputOnBlur: any}
 	{@param? _handleItemAdded: any}
@@ -31,6 +32,7 @@
 			{param creatable: false /}
 			{param dataSource: $_dataSource ?: [] /}
 			{param events: [
+				'errorAddinglabelItem': $_handleErrorAddinglabelItem,
 				'inputBlur': $_handleInputOnBlur,
 				'inputFocus': $_handleInputFocus,
 				'inputValueChanged': $_handleSyncInputValue,

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/categorization/EditCategories.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/categorization/EditCategories.es.js
@@ -84,6 +84,17 @@ class EditCategories extends Component {
 	}
 
 	/**
+	 * Checks if the vocabulary have errors
+	 *
+	 * @private
+	 * @review
+	 * @return {Boolean} true if it has a error, false if has not error.
+	 */
+	_checkErrors() {
+		return !!this.element.querySelector('.has-error');
+	}
+
+	/**
 	 * Creates the ajax request.
 	 *
 	 * @param {String} url Url of the request
@@ -242,7 +253,7 @@ class EditCategories extends Component {
 	_handleFormSubmit(event) {
 		event.preventDefault();
 
-		if (!this._validateRequiredVocabularies()) {
+		if (!this._validateRequiredVocabularies() || this._checkErrors()) {
 			return;
 		}
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/categorization/EditTags.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/categorization/EditTags.es.js
@@ -171,28 +171,23 @@ class EditTags extends Component {
 
 		let instance = this;
 
-		if ((addedTags.length > 0) || (removedTags.length > 0)) {
-			this._fetchTagsRequest(
-				this.urlUpdateTags,
-				this.append ? 'PATCH' : 'PUT',
-				{
-					documentBulkSelection: this._getSelection(),
-					keywordsToAdd: addedTags,
-					keywordsToRemove: removedTags
-				}
-			).then(
-				response => {
-					instance.close();
+		this._fetchTagsRequest(
+			this.urlUpdateTags,
+			this.append ? 'PATCH' : 'PUT',
+			{
+				documentBulkSelection: this._getSelection(),
+				keywordsToAdd: addedTags,
+				keywordsToRemove: removedTags
+			}
+		).then(
+			response => {
+				instance.close();
 
-					if (instance._bulkStatusComponent) {
-						instance._bulkStatusComponent.startWatch();
-					}
+				if (instance._bulkStatusComponent) {
+					instance._bulkStatusComponent.startWatch();
 				}
-			);
-		}
-		else {
-			instance.close();
-		}
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
Hey @boton, 
please check if it works as expected, and please review that submit event in EditCategories is being handled after the onBlur event in AssetVocabularyCategoriesSelector. 
Thnaks!