### PR TITLE
LPS-112374 rating star button disappear

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -168,6 +168,7 @@ Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(locale, timeZo
 				<c:if test="<%= commentTreeDisplayContext.isActionControlsVisible() && (index > 0) %>">
 					<div class="autofit-col">
 						<liferay-ui:icon-menu
+							cssClass="actions-menu"
 							direction="left-side"
 							icon="<%= StringPool.BLANK %>"
 							markupView="lexicon"

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_discussion.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_discussion.scss
@@ -75,12 +75,12 @@ $light-color: #e7e7ed;
 	}
 
 	@include media-breakpoint-up(sm) {
-		.dropdown {
+		.actions-menu {
 			display: none;
 		}
 
-		.comment-container:hover .dropdown,
-		.dropdown:focus {
+		.comment-container:hover .actions-menu,
+		.actions-menu:focus {
 			display: inline-block;
 		}
 	}

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_discussion.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/taglib/_discussion.scss
@@ -80,7 +80,8 @@ $light-color: #e7e7ed;
 		}
 
 		.comment-container:hover .actions-menu,
-		.actions-menu:focus {
+		.actions-menu:focus,
+		.actions-menu.open {
 			display: inline-block;
 		}
 	}


### PR DESCRIPTION
The rating button is disappearing when the hover is not over the comment, including the dropdown menu itself.

Applying the logic only to dropdown antion-menu and not hidden if is open.