### PR TITLE
LPD-26752 Test Select categories for the custom friendly URL

### DIFF
--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -6,7 +6,7 @@
 import {ApiHelpers} from './ApiHelpers';
 
 interface createVocabularyProps {
-	assetTypes: AssetType[];
+	assetTypes?: AssetType[];
 	name: string;
 	siteId: string;
 }
@@ -35,7 +35,7 @@ export class HeadlessAdminTaxonomyApiHelper {
 	 *
 	 * @param siteId the id of the site in which the vocabulary will be created
 	 * @param name the name of the vocabulary
-	 * @param assetTypes the asset types to which the vocabulary can be used
+	 * @param [assetTypes] the asset types to which the vocabulary can be used
 	 */
 
 	async createVocabulary({

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -38,7 +38,7 @@ export class DisplayPageTemplatesPage {
 	}) {
 		await this.newButton.click();
 		await this.page.getByRole('button', {name: 'Blank'}).click();
-		await this.page.getByLabel('Name').fill(name);
+		await this.page.getByLabel('Name', {exact: true}).fill(name);
 		await this.page
 			.getByLabel('Content Type')
 			.selectOption({label: contentType});

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -8,6 +8,15 @@ import {Locator, Page} from '@playwright/test';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 
+export enum DPT_CONTENT_SUBTYPE {
+	BASIC_WEB_CONTENT = 'Basic Web Content',
+}
+
+export enum DPT_CONTENT_TYPE {
+	WEB_CONTENT_ARTICLE = 'Web Content Article',
+	BLOGS_ENTRY = 'Blogs Entry',
+}
+
 export class DisplayPageTemplatesPage {
 	readonly page: Page;
 
@@ -32,8 +41,8 @@ export class DisplayPageTemplatesPage {
 		contentType,
 		name,
 	}: {
-		contentSubtype?: string;
-		contentType: string;
+		contentSubtype?: DPT_CONTENT_SUBTYPE;
+		contentType: DPT_CONTENT_TYPE;
 		name: string;
 	}) {
 		await this.newButton.click();

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -27,22 +27,34 @@ export class DisplayPageTemplatesPage {
 		);
 	}
 
-	async publishNewTemplate(name: string) {
+	async publishNewTemplate({
+		contentSubtype,
+		contentType,
+		name,
+	}: {
+		contentSubtype?: string;
+		contentType: string;
+		name: string;
+	}) {
 		await this.newButton.click();
 		await this.page.getByRole('button', {name: 'Blank'}).click();
 		await this.page.getByLabel('Name').fill(name);
 		await this.page
 			.getByLabel('Content Type')
-			.selectOption({label: 'Web Content Article'});
-		await this.page
-			.getByLabel('Subtype')
-			.selectOption({label: 'Basic Web Content'});
+			.selectOption({label: contentType});
+
+		if (contentSubtype) {
+			await this.page
+				.getByLabel('Subtype')
+				.selectOption({label: contentSubtype});
+		}
+
 		await this.page.getByRole('button', {name: 'Save'}).click();
 		await this.publishButton.waitFor();
 		await this.publishButton.click();
 	}
 
-	async clickMoreActions(name: string) {
+	private async clickMoreActions(name: string) {
 		await this.page
 			.locator(
 				'#_com_liferay_layout_page_template_admin_web_portlet_LayoutPageTemplatesPortlet_displayPagesSearchContainer .card-page-item'

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
 	expect: {
 		timeout: 15 * 1000,
 	},
-	forbidOnly: !!process.env.CI,
+	forbidOnly: false,
 	projects: [
 		accountAdminWebConfig,
 		analyticsSettingsWebConfig,

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -10,37 +10,41 @@ import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
 
-const baseTest = mergeTests(isolatedSiteTest, blogsPagesTest, loginTest());
+const test = mergeTests(isolatedSiteTest, blogsPagesTest, loginTest());
 
-const blogEntryAutoSaved = mergeTests(baseTest);
+test('LPD-22497: Permission sets are differing depending on autosaving of a blog entry', async ({
+	blogsEditBlogEntryPage,
+	blogsPage,
+	page,
+	site,
+}) => {
+	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
 
-blogEntryAutoSaved(
-	'LPD-22497: Permission sets are differing depending on autosaving of a blog entry',
-	async ({blogsEditBlogEntryPage, blogsPage, page, site}) => {
-		await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
+	const title = getRandomString();
 
-		const title = getRandomString();
+	await blogsEditBlogEntryPage.editBlogEntry({
+		content: getRandomString(),
+		publish: false,
+		title,
+	});
 
-		await blogsEditBlogEntryPage.editBlogEntry(getRandomString(), title);
+	await expect(
+		page.locator(
+			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_saveStatus'
+		)
+	).toContainText('Draft Saved at', {
+		timeout: 40000,
+	});
 
-		await expect(
-			page.locator(
-				'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_saveStatus'
-			)
-		).toContainText('Draft Saved at', {
-			timeout: 40000,
-		});
+	await blogsPage.goto(site.friendlyUrlPath);
 
-		await blogsPage.goto(site.friendlyUrlPath);
-
-		await blogsPage.assertBlogEntryPermissions(
-			[
-				{enabled: true, locator: '#guest_ACTION_ADD_DISCUSSION'},
-				{enabled: true, locator: '#guest_ACTION_VIEW'},
-				{enabled: true, locator: '#site-member_ACTION_ADD_DISCUSSION'},
-				{enabled: true, locator: '#site-member_ACTION_VIEW'},
-			],
-			title
-		);
-	}
-);
+	await blogsPage.assertBlogEntryPermissions(
+		[
+			{enabled: true, locator: '#guest_ACTION_ADD_DISCUSSION'},
+			{enabled: true, locator: '#guest_ACTION_VIEW'},
+			{enabled: true, locator: '#site-member_ACTION_ADD_DISCUSSION'},
+			{enabled: true, locator: '#site-member_ACTION_VIEW'},
+		],
+		title
+	);
+});

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -10,16 +10,10 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
-import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
-import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
-import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
-
-import type {ApiHelpers} from '../../helpers/ApiHelpers';
-import type {PageEditorPage} from '../../pages/layout-content-page-editor-web/PageEditorPage';
-import type {DisplayPageTemplatesPage} from '../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
+import {friendlyURLCategoriesSetup} from './setup';
 
 const test = mergeTests(
 	apiHelpersTest,
@@ -85,6 +79,7 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	await friendlyURLCategoriesSetup({
 		apiHelpers,
 		displayPageTemplatesPage,
+		friendlyUrlCategories,
 		page,
 		pageEditorPage,
 		site,
@@ -117,147 +112,3 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 		)}/${title}`
 	);
 });
-
-async function createAssetPublisherAndConfigure({
-	apiHelpers,
-	page,
-	pageEditorPage,
-	site,
-}: {
-	apiHelpers: ApiHelpers;
-	page;
-	pageEditorPage: PageEditorPage;
-	site: Site;
-}) {
-	const widgetId = getRandomString();
-
-	const widgetDefinition = getWidgetDefinition({
-		id: widgetId,
-		widgetName:
-			'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
-	});
-
-	const layout = await apiHelpers.headlessDelivery.createSitePage({
-		pageDefinition: getPageDefinition([widgetDefinition]),
-		siteId: site.id,
-		title: getRandomString(),
-	});
-
-	await pageEditorPage.goto(layout, site.friendlyUrlPath);
-
-	const topper = pageEditorPage.getTopper(widgetId);
-
-	await topper.hover();
-	await clickAndExpectToBeVisible({
-		autoClick: true,
-		target: page.getByRole('menuitem', {
-			exact: true,
-			name: 'Configuration',
-		}),
-		trigger: topper.locator('.portlet-options'),
-	});
-
-	const assetPublisherConfigurationIframe = await page.frameLocator(
-		'iframe[title="Asset Publisher\\a      - Configuration"]'
-	);
-
-	const assetPublisherConfigurationDynamicRadio =
-		assetPublisherConfigurationIframe.getByText('Dynamic', {exact: true});
-	await assetPublisherConfigurationDynamicRadio.waitFor();
-	if (await assetPublisherConfigurationDynamicRadio.isHidden()) {
-		await assetPublisherConfigurationIframe
-			.getByRole('link', {name: 'Asset Selection'})
-			.click();
-	}
-	await assetPublisherConfigurationDynamicRadio.click();
-
-	const assetPublisherConfigurationSourceAssetTypeSelect =
-		await assetPublisherConfigurationIframe.getByLabel('Asset Type');
-	if (await assetPublisherConfigurationSourceAssetTypeSelect.isHidden()) {
-		await assetPublisherConfigurationIframe
-			.getByRole('link', {name: 'Source'})
-			.click();
-	}
-	await assetPublisherConfigurationSourceAssetTypeSelect.selectOption({
-		label: 'Blogs Entry',
-	});
-
-	await assetPublisherConfigurationIframe
-		.getByRole('button', {name: 'Save'})
-		.click();
-
-	await page.getByLabel('close', {exact: true}).click();
-	await page.getByLabel('Publish', {exact: true}).click();
-
-	await waitForSuccessAlert(
-		page,
-		'Success:The page was published successfully.'
-	);
-}
-
-async function createCategories({
-	apiHelpers,
-	site,
-	vocabularyName,
-}: {
-	apiHelpers: ApiHelpers;
-	site: Site;
-	vocabularyName: string;
-}) {
-	const {id: vocabularyId} =
-		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
-			name: vocabularyName,
-			siteId: site.id,
-		});
-
-	for (const categoryName of friendlyUrlCategories) {
-		await apiHelpers.headlessAdminTaxonomy.createCategory({
-			name: categoryName,
-			vocabularyId,
-		});
-	}
-}
-
-async function createDPTandMarkAsDefault({
-	displayPageTemplatesPage,
-	site,
-}: {
-	displayPageTemplatesPage: DisplayPageTemplatesPage;
-	site: Site;
-}) {
-	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
-
-	const displayPageTemplateName = getRandomString();
-
-	await displayPageTemplatesPage.publishNewTemplate({
-		contentType: 'Blogs Entry',
-		name: displayPageTemplateName,
-	});
-
-	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
-}
-
-async function friendlyURLCategoriesSetup({
-	apiHelpers,
-	displayPageTemplatesPage,
-	page,
-	pageEditorPage,
-	site,
-	vocabularyName,
-}: {
-	apiHelpers: ApiHelpers;
-	displayPageTemplatesPage: DisplayPageTemplatesPage;
-	page;
-	pageEditorPage: PageEditorPage;
-	site: Site;
-	vocabularyName: string;
-}) {
-	await createCategories({apiHelpers, site, vocabularyName});
-	await createDPTandMarkAsDefault({displayPageTemplatesPage, site});
-	await createAssetPublisherAndConfigure({
-		apiHelpers,
-		page,
-		pageEditorPage,
-		site,
-	});
-}

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -66,7 +66,7 @@ test('LPD-22497: Permission sets are differing depending on autosaving of a blog
 
 const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
 
-test('LPD-26752 Select categories for the custom friendly URL', async ({
+test.only('LPD-26752 Select categories for the custom friendly URL', async ({
 	apiHelpers,
 	blogsEditBlogEntryPage,
 	displayPageTemplatesPage,

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -9,16 +9,23 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
+import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
 
 const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
 	blogsPagesTest,
+	pageEditorPagesTest,
 	loginTest(),
 	featureFlagsTest({
 		'LPD-11147': true,
+		'LPS-178052': true,
 	})
 );
 
@@ -66,6 +73,7 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	blogsEditBlogEntryPage,
 	displayPageTemplatesPage,
 	page,
+	pageEditorPage,
 	site,
 }) => {
 	const vocabularyName = getRandomString();
@@ -93,6 +101,71 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	});
 
 	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
+
+	const widgetId = getRandomString();
+
+	const widgetDefinition = getWidgetDefinition({
+		id: widgetId,
+		widgetName:
+			'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+	});
+
+	const layout = await apiHelpers.headlessDelivery.createSitePage({
+		pageDefinition: getPageDefinition([widgetDefinition]),
+		siteId: site.id,
+		title: getRandomString(),
+	});
+
+	await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+	const topper = await pageEditorPage.getTopper(widgetId);
+
+	await topper.hover();
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: page.getByRole('menuitem', {
+			exact: true,
+			name: 'Configuration',
+		}),
+		trigger: topper.locator('.portlet-options'),
+	});
+
+	const assetPublisherConfigurationIframe = await page.frameLocator(
+		'iframe[title="Asset Publisher\\a      - Configuration"]'
+	);
+
+	const assetPublisherConfigurationDynamicRadio =
+		assetPublisherConfigurationIframe.getByText('Dynamic', {exact: true});
+	await assetPublisherConfigurationDynamicRadio.waitFor();
+	if (await assetPublisherConfigurationDynamicRadio.isHidden()) {
+		await assetPublisherConfigurationIframe
+			.getByRole('link', {name: 'Asset Selection'})
+			.click();
+	}
+	await assetPublisherConfigurationDynamicRadio.click();
+
+	const assetPublisherConfigurationSourceAssetTypeSelect =
+		await assetPublisherConfigurationIframe.getByLabel('Asset Type');
+	if (await assetPublisherConfigurationSourceAssetTypeSelect.isHidden()) {
+		await assetPublisherConfigurationIframe
+			.getByRole('link', {name: 'Source'})
+			.click();
+	}
+	await assetPublisherConfigurationSourceAssetTypeSelect.selectOption({
+		label: 'Blogs Entry',
+	});
+
+	await assetPublisherConfigurationIframe
+		.getByRole('button', {name: 'Save'})
+		.click();
+
+	await page.getByLabel('close', {exact: true}).click();
+	await page.getByLabel('Publish', {exact: true}).click();
+
+	await waitForSuccessAlert(
+		page,
+		'Success:The page was published successfully.'
+	);
 
 	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -64,6 +64,7 @@ const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
 test('LPD-26752 Select categories for the custom friendly URL', async ({
 	apiHelpers,
 	blogsEditBlogEntryPage,
+	displayPageTemplatesPage,
 	page,
 	site,
 }) => {
@@ -81,6 +82,17 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 			vocabularyId,
 		});
 	}
+
+	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+	const displayPageTemplateName = getRandomString();
+
+	await displayPageTemplatesPage.publishNewTemplate({
+		contentType: 'Blogs Entry',
+		name: displayPageTemplateName,
+	});
+
+	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
 
 	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -181,4 +181,15 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 	await expect(
 		page.getByText(`/-/blogs/${friendlyUrlCategories.join('/')}/`)
 	).toBeVisible();
+
+	await page.getByRole('button', {name: 'Publish'}).click();
+	await waitForSuccessAlert(page);
+
+	const response = await page.goto(`/web${site.friendlyUrlPath}/b/${title}`);
+
+	await expect(response.url()).toContain(
+		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories.join(
+			'/'
+		)}/${title}`
+	);
 });

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -5,12 +5,22 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
 
-const test = mergeTests(isolatedSiteTest, blogsPagesTest, loginTest());
+const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	blogsPagesTest,
+	loginTest(),
+	featureFlagsTest({
+		'LPD-11147': true,
+	})
+);
 
 test('LPD-22497: Permission sets are differing depending on autosaving of a blog entry', async ({
 	blogsEditBlogEntryPage,
@@ -47,4 +57,43 @@ test('LPD-22497: Permission sets are differing depending on autosaving of a blog
 		],
 		title
 	);
+});
+
+const friendlyUrlCategories = ['category-1', 'category-2', 'category-3'];
+
+test('LPD-26752 Select categories for the custom friendly URL', async ({
+	apiHelpers,
+	blogsEditBlogEntryPage,
+	page,
+	site,
+}) => {
+	const vocabularyName = getRandomString();
+
+	const {id: vocabularyId} =
+		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
+			name: vocabularyName,
+			siteId: site.id,
+		});
+
+	for (const categoryName of friendlyUrlCategories) {
+		await apiHelpers.headlessAdminTaxonomy.createCategory({
+			name: categoryName,
+			vocabularyId,
+		});
+	}
+
+	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
+
+	const title = getRandomString();
+
+	await blogsEditBlogEntryPage.editBlogEntry({
+		content: getRandomString(),
+		friendlyUrl: {categories: friendlyUrlCategories},
+		publish: false,
+		title,
+	});
+
+	await expect(
+		page.getByText(`/-/blogs/${friendlyUrlCategories.join('/')}/`)
+	).toBeVisible();
 });

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -88,7 +88,7 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 
 	await blogsEditBlogEntryPage.editBlogEntry({
 		content: getRandomString(),
-		friendlyUrl: {categories: friendlyUrlCategories},
+		friendlyUrl: {categories: friendlyUrlCategories, vocabularyName},
 		publish: false,
 		title,
 	});

--- a/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
+++ b/modules/test/playwright/tests/blogs-web/blogEntry.spec.ts
@@ -17,6 +17,10 @@ import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDe
 import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
 import {blogsPagesTest} from './fixtures/blogsPagesTest';
 
+import type {ApiHelpers} from '../../helpers/ApiHelpers';
+import type {PageEditorPage} from '../../pages/layout-content-page-editor-web/PageEditorPage';
+import type {DisplayPageTemplatesPage} from '../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
+
 const test = mergeTests(
 	apiHelpersTest,
 	isolatedSiteTest,
@@ -78,30 +82,53 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 }) => {
 	const vocabularyName = getRandomString();
 
-	const {id: vocabularyId} =
-		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
-			name: vocabularyName,
-			siteId: site.id,
-		});
-
-	for (const categoryName of friendlyUrlCategories) {
-		await apiHelpers.headlessAdminTaxonomy.createCategory({
-			name: categoryName,
-			vocabularyId,
-		});
-	}
-
-	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
-
-	const displayPageTemplateName = getRandomString();
-
-	await displayPageTemplatesPage.publishNewTemplate({
-		contentType: 'Blogs Entry',
-		name: displayPageTemplateName,
+	await friendlyURLCategoriesSetup({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+		site,
+		vocabularyName,
 	});
 
-	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
+	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
 
+	const title = getRandomString();
+
+	await blogsEditBlogEntryPage.editBlogEntry({
+		content: getRandomString(),
+		friendlyUrl: {categories: friendlyUrlCategories, vocabularyName},
+		publish: false,
+		title,
+	});
+
+	await expect(
+		page.getByText(`/-/blogs/${friendlyUrlCategories.join('/')}/`)
+	).toBeVisible();
+
+	await page.getByRole('button', {name: 'Publish'}).click();
+	await waitForSuccessAlert(page);
+
+	const response = await page.goto(`/web${site.friendlyUrlPath}/b/${title}`);
+
+	await expect(response.url()).toContain(
+		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories.join(
+			'/'
+		)}/${title}`
+	);
+});
+
+async function createAssetPublisherAndConfigure({
+	apiHelpers,
+	page,
+	pageEditorPage,
+	site,
+}: {
+	apiHelpers: ApiHelpers;
+	page;
+	pageEditorPage: PageEditorPage;
+	site: Site;
+}) {
 	const widgetId = getRandomString();
 
 	const widgetDefinition = getWidgetDefinition({
@@ -118,7 +145,7 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 
 	await pageEditorPage.goto(layout, site.friendlyUrlPath);
 
-	const topper = await pageEditorPage.getTopper(widgetId);
+	const topper = pageEditorPage.getTopper(widgetId);
 
 	await topper.hover();
 	await clickAndExpectToBeVisible({
@@ -166,30 +193,71 @@ test('LPD-26752 Select categories for the custom friendly URL', async ({
 		page,
 		'Success:The page was published successfully.'
 	);
+}
 
-	await blogsEditBlogEntryPage.goto(site.friendlyUrlPath);
+async function createCategories({
+	apiHelpers,
+	site,
+	vocabularyName,
+}: {
+	apiHelpers: ApiHelpers;
+	site: Site;
+	vocabularyName: string;
+}) {
+	const {id: vocabularyId} =
+		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
+			name: vocabularyName,
+			siteId: site.id,
+		});
 
-	const title = getRandomString();
+	for (const categoryName of friendlyUrlCategories) {
+		await apiHelpers.headlessAdminTaxonomy.createCategory({
+			name: categoryName,
+			vocabularyId,
+		});
+	}
+}
 
-	await blogsEditBlogEntryPage.editBlogEntry({
-		content: getRandomString(),
-		friendlyUrl: {categories: friendlyUrlCategories, vocabularyName},
-		publish: false,
-		title,
+async function createDPTandMarkAsDefault({
+	displayPageTemplatesPage,
+	site,
+}: {
+	displayPageTemplatesPage: DisplayPageTemplatesPage;
+	site: Site;
+}) {
+	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+	const displayPageTemplateName = getRandomString();
+
+	await displayPageTemplatesPage.publishNewTemplate({
+		contentType: 'Blogs Entry',
+		name: displayPageTemplateName,
 	});
 
-	await expect(
-		page.getByText(`/-/blogs/${friendlyUrlCategories.join('/')}/`)
-	).toBeVisible();
+	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
+}
 
-	await page.getByRole('button', {name: 'Publish'}).click();
-	await waitForSuccessAlert(page);
-
-	const response = await page.goto(`/web${site.friendlyUrlPath}/b/${title}`);
-
-	await expect(response.url()).toContain(
-		`/web${site.friendlyUrlPath}/b/${friendlyUrlCategories.join(
-			'/'
-		)}/${title}`
-	);
-});
+async function friendlyURLCategoriesSetup({
+	apiHelpers,
+	displayPageTemplatesPage,
+	page,
+	pageEditorPage,
+	site,
+	vocabularyName,
+}: {
+	apiHelpers: ApiHelpers;
+	displayPageTemplatesPage: DisplayPageTemplatesPage;
+	page;
+	pageEditorPage: PageEditorPage;
+	site: Site;
+	vocabularyName: string;
+}) {
+	await createCategories({apiHelpers, site, vocabularyName});
+	await createDPTandMarkAsDefault({displayPageTemplatesPage, site});
+	await createAssetPublisherAndConfigure({
+		apiHelpers,
+		page,
+		pageEditorPage,
+		site,
+	});
+}

--- a/modules/test/playwright/tests/blogs-web/fixtures/blogsPagesTest.ts
+++ b/modules/test/playwright/tests/blogs-web/fixtures/blogsPagesTest.ts
@@ -5,18 +5,23 @@
 
 import {test} from '@playwright/test';
 
+import {DisplayPageTemplatesPage} from '../../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
 import {BlogsEditBlogEntryPage} from '../pages/BlogsEditBlogEntryPage';
 import {BlogsPage} from '../pages/BlogsPage';
 
 const blogsPagesTest = test.extend<{
 	blogsEditBlogEntryPage: BlogsEditBlogEntryPage;
 	blogsPage: BlogsPage;
+	displayPageTemplatesPage: DisplayPageTemplatesPage;
 }>({
 	blogsEditBlogEntryPage: async ({page}, use) => {
 		await use(new BlogsEditBlogEntryPage(page));
 	},
 	blogsPage: async ({page}, use) => {
 		await use(new BlogsPage(page));
+	},
+	displayPageTemplatesPage: async ({page}, use) => {
+		await use(new DisplayPageTemplatesPage(page));
 	},
 });
 

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -12,11 +12,15 @@ export class BlogsEditBlogEntryPage {
 
 	readonly blogsPage: BlogsPage;
 	readonly publishButton: Locator;
+	readonly contentEditor: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
 
 		this.blogsPage = new BlogsPage(page);
+		this.contentEditor = page.locator(
+			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor.cke_editable'
+		);
 		this.publishButton = page.getByRole('button', {name: 'Publish'});
 	}
 
@@ -25,26 +29,60 @@ export class BlogsEditBlogEntryPage {
 		await this.blogsPage.goToCreateBlogEntry();
 	}
 
+	private async editBlogEntryAddfriendlyUrl({
+		categories,
+	}: {
+		categories: string[];
+	}) {
+		const fieldset = await this.page.locator(
+			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_friendly-url'
+		);
+
+		if (await fieldset.locator('.panel-body').isHidden()) {
+			await fieldset.getByRole('button', {name: 'Friendly URL'}).click();
+		}
+
+		await fieldset.getByText('Use a Customized URL').click();
+		await fieldset.getByRole('button', {name: 'Select'}).click();
+
+		const categoriesSelectorIframe = await this.page.frameLocator(
+			'iframe[title="Filter by Categories"]'
+		);
+
+		await categoriesSelectorIframe.getByText('Test').click();
+
+		for (const categoryName of categories) {
+			await categoriesSelectorIframe.getByText(categoryName).click();
+		}
+
+		await this.page
+			.getByLabel('Filter by Categories')
+			.getByRole('button', {name: 'Select'})
+			.click();
+	}
+
 	async editBlogEntry({
 		content,
+		friendlyUrl,
 		publish = true,
 		title,
 	}: {
 		content: string;
+		friendlyUrl?: {categories: string[]};
 		publish?: boolean;
 		title: string;
 	}) {
-		await this.page.getByPlaceholder('Title *').waitFor();
-
 		await this.page.getByPlaceholder('Title *').fill(title);
 
-		await this.page.getByRole('paragraph').click();
+		await this.contentEditor.fill(content);
 
-		await this.page
-			.locator(
-				'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor'
-			)
-			.fill(content);
+		const {categories} = friendlyUrl;
+
+		if (categories?.length) {
+			await this.editBlogEntryAddfriendlyUrl({
+				categories,
+			});
+		}
 
 		if (publish) {
 			await this.publishButton.click();

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -11,19 +11,13 @@ export class BlogsEditBlogEntryPage {
 	readonly page: Page;
 
 	readonly blogsPage: BlogsPage;
-	readonly propertiesTab: Locator;
 	readonly publishButton: Locator;
-	readonly titlePlaceholder: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
 
 		this.blogsPage = new BlogsPage(page);
-		this.propertiesTab = page.getByRole('tab', {name: 'Properties'});
 		this.publishButton = page.getByRole('button', {name: 'Publish'});
-		this.titlePlaceholder = page.getByPlaceholder(
-			'Untitled Basic Web Content'
-		);
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
@@ -40,7 +34,7 @@ export class BlogsEditBlogEntryPage {
 
 		await this.page
 			.locator(
-				'[id="_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor"]'
+				'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor'
 			)
 			.fill(content);
 	}

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -7,6 +7,11 @@ import {Locator, Page} from '@playwright/test';
 
 import {BlogsPage} from './BlogsPage';
 
+type editBlogEntryAddfriendlyUrlType = {
+	categories: string[];
+	vocabularyName: string;
+};
+
 export class BlogsEditBlogEntryPage {
 	readonly page: Page;
 
@@ -31,9 +36,8 @@ export class BlogsEditBlogEntryPage {
 
 	private async editBlogEntryAddfriendlyUrl({
 		categories,
-	}: {
-		categories: string[];
-	}) {
+		vocabularyName,
+	}: editBlogEntryAddfriendlyUrlType) {
 		const fieldset = await this.page.locator(
 			'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_friendly-url'
 		);
@@ -49,7 +53,7 @@ export class BlogsEditBlogEntryPage {
 			'iframe[title="Filter by Categories"]'
 		);
 
-		await categoriesSelectorIframe.getByText('Test').click();
+		await categoriesSelectorIframe.getByText(vocabularyName).click();
 
 		for (const categoryName of categories) {
 			await categoriesSelectorIframe.getByText(categoryName).click();
@@ -68,7 +72,7 @@ export class BlogsEditBlogEntryPage {
 		title,
 	}: {
 		content: string;
-		friendlyUrl?: {categories: string[]};
+		friendlyUrl?: editBlogEntryAddfriendlyUrlType;
 		publish?: boolean;
 		title: string;
 	}) {
@@ -76,11 +80,12 @@ export class BlogsEditBlogEntryPage {
 
 		await this.contentEditor.fill(content);
 
-		const {categories} = friendlyUrl;
+		if (friendlyUrl) {
+			const {categories, vocabularyName} = friendlyUrl;
 
-		if (categories?.length) {
 			await this.editBlogEntryAddfriendlyUrl({
 				categories,
+				vocabularyName,
 			});
 		}
 

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -25,7 +25,15 @@ export class BlogsEditBlogEntryPage {
 		await this.blogsPage.goToCreateBlogEntry();
 	}
 
-	async editBlogEntry(content: string, title: string) {
+	async editBlogEntry({
+		content,
+		publish = true,
+		title,
+	}: {
+		content: string;
+		publish?: boolean;
+		title: string;
+	}) {
 		await this.page.getByPlaceholder('Title *').waitFor();
 
 		await this.page.getByPlaceholder('Title *').fill(title);
@@ -37,5 +45,9 @@ export class BlogsEditBlogEntryPage {
 				'#_com_liferay_blogs_web_portlet_BlogsAdminPortlet_contentEditor'
 			)
 			.fill(content);
+
+		if (publish) {
+			await this.publishButton.click();
+		}
 	}
 }

--- a/modules/test/playwright/tests/blogs-web/setup.ts
+++ b/modules/test/playwright/tests/blogs-web/setup.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {DPT_CONTENT_TYPE} from '../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
@@ -127,7 +128,7 @@ async function createDPTandMarkAsDefault({
 	const displayPageTemplateName = getRandomString();
 
 	await displayPageTemplatesPage.publishNewTemplate({
-		contentType: 'Blogs Entry',
+		contentType: DPT_CONTENT_TYPE.BLOGS_ENTRY,
 		name: displayPageTemplateName,
 	});
 

--- a/modules/test/playwright/tests/blogs-web/setup.ts
+++ b/modules/test/playwright/tests/blogs-web/setup.ts
@@ -1,0 +1,166 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../utils/getRandomString';
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
+import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
+
+import type {ApiHelpers} from '../../helpers/ApiHelpers';
+import type {PageEditorPage} from '../../pages/layout-content-page-editor-web/PageEditorPage';
+import type {DisplayPageTemplatesPage} from '../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
+
+async function createAssetPublisherAndConfigure({
+	apiHelpers,
+	page,
+	pageEditorPage,
+	site,
+}: {
+	apiHelpers: ApiHelpers;
+	page;
+	pageEditorPage: PageEditorPage;
+	site: Site;
+}) {
+	const widgetId = getRandomString();
+
+	const widgetDefinition = getWidgetDefinition({
+		id: widgetId,
+		widgetName:
+			'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+	});
+
+	const layout = await apiHelpers.headlessDelivery.createSitePage({
+		pageDefinition: getPageDefinition([widgetDefinition]),
+		siteId: site.id,
+		title: getRandomString(),
+	});
+
+	await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+	const topper = pageEditorPage.getTopper(widgetId);
+
+	await topper.hover();
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: page.getByRole('menuitem', {
+			exact: true,
+			name: 'Configuration',
+		}),
+		trigger: topper.locator('.portlet-options'),
+	});
+
+	const assetPublisherConfigurationIframe = await page.frameLocator(
+		'iframe[title="Asset Publisher\\a      - Configuration"]'
+	);
+
+	const assetPublisherConfigurationDynamicRadio =
+		assetPublisherConfigurationIframe.getByText('Dynamic', {exact: true});
+	await assetPublisherConfigurationDynamicRadio.waitFor();
+	if (await assetPublisherConfigurationDynamicRadio.isHidden()) {
+		await assetPublisherConfigurationIframe
+			.getByRole('link', {name: 'Asset Selection'})
+			.click();
+	}
+	await assetPublisherConfigurationDynamicRadio.click();
+
+	const assetPublisherConfigurationSourceAssetTypeSelect =
+		await assetPublisherConfigurationIframe.getByLabel('Asset Type');
+	if (await assetPublisherConfigurationSourceAssetTypeSelect.isHidden()) {
+		await assetPublisherConfigurationIframe
+			.getByRole('link', {name: 'Source'})
+			.click();
+	}
+	await assetPublisherConfigurationSourceAssetTypeSelect.selectOption({
+		label: 'Blogs Entry',
+	});
+
+	await assetPublisherConfigurationIframe
+		.getByRole('button', {name: 'Save'})
+		.click();
+
+	await page.getByLabel('close', {exact: true}).click();
+	await page.getByLabel('Publish', {exact: true}).click();
+
+	await waitForSuccessAlert(
+		page,
+		'Success:The page was published successfully.'
+	);
+}
+
+async function createCategories({
+	apiHelpers,
+	friendlyUrlCategories,
+	site,
+	vocabularyName,
+}: {
+	apiHelpers: ApiHelpers;
+	friendlyUrlCategories: string[];
+	site: Site;
+	vocabularyName: string;
+}) {
+	const {id: vocabularyId} =
+		await apiHelpers.headlessAdminTaxonomy.createVocabulary({
+			name: vocabularyName,
+			siteId: site.id,
+		});
+
+	for (const categoryName of friendlyUrlCategories) {
+		await apiHelpers.headlessAdminTaxonomy.createCategory({
+			name: categoryName,
+			vocabularyId,
+		});
+	}
+}
+
+async function createDPTandMarkAsDefault({
+	displayPageTemplatesPage,
+	site,
+}: {
+	displayPageTemplatesPage: DisplayPageTemplatesPage;
+	site: Site;
+}) {
+	await displayPageTemplatesPage.goto(site.friendlyUrlPath);
+
+	const displayPageTemplateName = getRandomString();
+
+	await displayPageTemplatesPage.publishNewTemplate({
+		contentType: 'Blogs Entry',
+		name: displayPageTemplateName,
+	});
+
+	await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
+}
+export async function friendlyURLCategoriesSetup({
+	apiHelpers,
+	displayPageTemplatesPage,
+	friendlyUrlCategories,
+	page,
+	pageEditorPage,
+	site,
+	vocabularyName,
+}: {
+	apiHelpers: ApiHelpers;
+	displayPageTemplatesPage: DisplayPageTemplatesPage;
+	friendlyUrlCategories: string[];
+	page;
+	pageEditorPage: PageEditorPage;
+	site: Site;
+	vocabularyName: string;
+}) {
+	await createCategories({
+		apiHelpers,
+		friendlyUrlCategories,
+		site,
+		vocabularyName,
+	});
+	await createDPTandMarkAsDefault({displayPageTemplatesPage, site});
+	await createAssetPublisherAndConfigure({
+		apiHelpers,
+		page,
+		pageEditorPage,
+		site,
+	});
+}

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -11,6 +11,10 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
+import {
+	DPT_CONTENT_SUBTYPE,
+	DPT_CONTENT_TYPE,
+} from '../../pages/layout-page-template-admin-web/DisplayPageTemplatesPage';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import getRandomString from '../../utils/getRandomString';
@@ -240,8 +244,8 @@ prefixUrlTest(
 		const displayPageTemplateName = getRandomString();
 
 		await displayPageTemplatesPage.publishNewTemplate({
-			contentSubtype: 'Basic Web Content',
-			contentType: 'Web Content Article',
+			contentSubtype: DPT_CONTENT_SUBTYPE.BASIC_WEB_CONTENT,
+			contentType: DPT_CONTENT_TYPE.WEB_CONTENT_ARTICLE,
 			name: displayPageTemplateName,
 		});
 

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -217,7 +217,7 @@ privateContentIconTest(
 	}
 );
 
-prefixUrlTest(
+prefixUrlTest.only(
 	'LPD-6813: Make prefix URLs configurable',
 	async ({
 		apiHelpers,

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -239,9 +239,11 @@ prefixUrlTest(
 
 		const displayPageTemplateName = getRandomString();
 
-		await displayPageTemplatesPage.publishNewTemplate(
-			displayPageTemplateName
-		);
+		await displayPageTemplatesPage.publishNewTemplate({
+			contentSubtype: 'Basic Web Content',
+			contentType: 'Web Content Article',
+			name: displayPageTemplateName,
+		});
 
 		await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
 


### PR DESCRIPTION
> [!CAUTION]
> The last commit is only for testing purposes **NOT MERGE** as is.

---

# I have questions

1. Is it a good idea to split the setup this way? 2e167c0 809ba3f
2. Is it good to use `enum` to type + force constant the options? 26faa7d3a595a819a5848208e1f3333770d5e525

---

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-26752

We are adding tests to Epic https://liferay.atlassian.net/browse/LPD-11147 use cases.

# How am I testing?

We are trying to test if a user adds categories to a blog entry via UI, 

- ✅ The addon URL preview is the expected.
- ✅ The redirect with the categories is created


# How can you verify that it works?

1. Go to `/modules/test/playwright`
3. Run `npm install` (setup)
4. Run `npm run test -- -g "LPD-26752|LPD-6813"` to only run the new test and affected test

![image](https://github.com/boton/liferay-portal/assets/67901/fdc1d53d-109d-4fa8-bdd3-76dff10a85fd)


# Screenrecord tests execution

<details open>
  <summary>New test</summary>

[blogEntry-LPD-26752-Select-categories-for-the-custom-friendly-URL-blogs-web.webm](https://github.com/boton/liferay-portal/assets/67901/4904a657-326c-4d89-aa2f-269f0a79f18e)

</details>

<details>
  <summary>Affected test</summary>
  
[journalArticle-LPD-6813-Make-prefix-URLs-configurable-journal-web.webm](https://github.com/boton/liferay-portal/assets/67901/71f36596-10f4-4fd9-95ee-b4e1ca2c0485)

</details>
