### PR TITLE
Ensure SPA navigation using navigate for link type actions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/handleActionClick.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/handleActionClick.ts
@@ -146,15 +146,14 @@ const handleActionClick = ({
 		}
 	};
 
+	let defaultPrevented = false;
+
+	if (target === 'link') {
+		event.preventDefault();
+
+		defaultPrevented = true;
+	}
 	if (confirmationMessage) {
-		let defaultPrevented = false;
-
-		if (target === 'link') {
-			event.preventDefault();
-
-			defaultPrevented = true;
-		}
-
 		openConfirmModal({
 			message: confirmationMessage,
 			onConfirm: (isConfirmed) => {
@@ -167,7 +166,7 @@ const handleActionClick = ({
 		});
 	}
 	else {
-		doAction({defaultPrevented: false});
+		doAction({defaultPrevented});
 	}
 
 	if (closeMenu) {


### PR DESCRIPTION
This PR proposes using navigate consistently for all link-type actions in FDS, not just when a confirmation is set. 
This ensures proper SPA behavior across all cases. 

Jest tests passed locally.
<img width="520" height="322" alt="image" src="https://github.com/user-attachments/assets/d40a8c2a-84b3-4d4f-a196-796cbd93836c" />
